### PR TITLE
Add some more opcodes and fix export

### DIFF
--- a/src/HdmiCecAnalyzerResults.cpp
+++ b/src/HdmiCecAnalyzerResults.cpp
@@ -61,6 +61,7 @@ void HdmiCecAnalyzerResults::GenerateFrameTabularText( U64 frame_index, DisplayB
         std::string dataStr = GetNumberString( frame.mData1, 8 );
 
         std::string str = "Data " + dataStr;
+        AddTabularText( str.c_str() );
     }
 
     break;
@@ -156,7 +157,7 @@ void HdmiCecAnalyzerResults::GenerateExportFile( const char* file, DisplayBase d
             }
             else if( frameType == HdmiCec::FrameType_Operand )
             {
-                dataDesc = naString;
+                dataDesc = "Data " + GetNumberString( frame.mData1, 8 );
             }
             else
             {

--- a/src/HdmiCecProtocol.cpp
+++ b/src/HdmiCecProtocol.cpp
@@ -187,6 +187,32 @@ namespace HdmiCec
             return "SystemAudioModeStatus";
         case OpCode_SetAudioRate:
             return "SetAudioRate";
+        case OpCode_ReportShortAudioDescriptor:
+            return "ReportShortAudioDescriptor";
+        case OpCode_RequestShortAudioDescriptor:
+            return "RequestShortAudioDescriptor";
+        case OpCode_GiveFeatures:
+            return "GiveFeatures";
+        case OpCode_ReportFeatures:
+            return "ReportFeatures";
+        case OpCode_RequestCurrentLatency:
+            return "RequestCurrentLatency";
+        case OpCode_ReportCurrentLatency:
+            return "ReportCurrentLatency";
+        case OpCode_InitiateArc:
+            return "InitiateArc";
+        case OpCode_ReportArcInitiated:
+            return "ReportArcInitiated";
+        case OpCode_ReportArcTerminated:
+            return "ReportArcTerminated";
+        case OpCode_RequestArcInitiation:
+            return "RequestArcInitiation";
+        case OpCode_RequestArcTermination:
+            return "RequestArcTermination";
+        case OpCode_TerminateArc:
+            return "TerminateArc";
+        case OpCode_CDCMessage:
+            return "CDCMessage";
         default:
             break;
         }

--- a/src/HdmiCecProtocol.h
+++ b/src/HdmiCecProtocol.h
@@ -172,7 +172,20 @@ namespace HdmiCec
         OpCode_SetSystemAudioMode = 0x72,
         OpCode_SystemAudioModeRequest = 0x70,
         OpCode_SystemAudioModeStatus = 0x7e,
-        OpCode_SetAudioRate = 0x9a
+        OpCode_SetAudioRate = 0x9a,
+        OpCode_ReportShortAudioDescriptor = 0xa3,
+        OpCode_RequestShortAudioDescriptor = 0xa4,
+        OpCode_GiveFeatures = 0xa5,
+        OpCode_ReportFeatures = 0xa6,
+        OpCode_RequestCurrentLatency = 0xa7,
+        OpCode_ReportCurrentLatency = 0xa8,
+        OpCode_InitiateArc = 0xc0,
+        OpCode_ReportArcInitiated = 0xc1,
+        OpCode_ReportArcTerminated = 0xc2,
+        OpCode_RequestArcInitiation = 0xc3,
+        OpCode_RequestArcTermination = 0xc4,
+        OpCode_TerminateArc = 0xc5,
+        OpCode_CDCMessage = 0xf8
     };
 
     const char* GetOpCodeString( OpCode opCode );


### PR DESCRIPTION
Tested with Logic 1.2.18, but I wasn't able to test it with Logic 2.x
Should fix https://github.com/saleae/hdmi-cec-analyzer/issues/1 and fix https://github.com/saleae/hdmi-cec-analyzer/issues/2